### PR TITLE
DDD Setting + Add user entity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -289,11 +289,35 @@
                 "@types/koa": "*"
             }
         },
+        "@types/lodash": {
+            "version": "4.14.149",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+            "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
+            "dev": true
+        },
         "@types/mime": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
             "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
             "dev": true
+        },
+        "@types/moment": {
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/@types/moment/-/moment-2.13.0.tgz",
+            "integrity": "sha1-YE69GJvDvDShVIaJQE5hoqSqyJY=",
+            "dev": true,
+            "requires": {
+                "moment": "*"
+            }
+        },
+        "@types/moment-timezone": {
+            "version": "0.5.12",
+            "resolved": "https://registry.npmjs.org/@types/moment-timezone/-/moment-timezone-0.5.12.tgz",
+            "integrity": "sha512-hnHH2+Efg2vExr/dSz+IX860nSiyk9Sk4pJF2EmS11lRpMcNXeB4KBW5xcgw2QPsb9amTXdsVNEe5IoJXiT0uw==",
+            "dev": true,
+            "requires": {
+                "moment": ">=2.14.0"
+            }
         },
         "@types/node": {
             "version": "12.12.14",
@@ -326,6 +350,15 @@
             "requires": {
                 "@types/express-serve-static-core": "*",
                 "@types/mime": "*"
+            }
+        },
+        "@types/sha.js": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@types/sha.js/-/sha.js-2.4.0.tgz",
+            "integrity": "sha512-amxKgPy6WJTKuw8mpUwjX2BSxuBtBmZfRwIUDIuPJKNwGN8CWDli8JTg5ONTWOtcTkHIstvT7oAhhYXqEjStHQ==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
             }
         },
         "@types/uuid": {
@@ -634,6 +667,11 @@
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
             "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
             "dev": true
+        },
+        "class-transformer": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.2.3.tgz",
+            "integrity": "sha512-qsP+0xoavpOlJHuYsQJsN58HXSl8Jvveo+T37rEvCEeRfMWoytAyR0Ua/YsFgpM6AZYZ/og2PJwArwzJl1aXtQ=="
         },
         "class-validator": {
             "version": "0.9.1",
@@ -2509,6 +2547,19 @@
                 "minimist": "0.0.8"
             }
         },
+        "moment": {
+            "version": "2.24.0",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+            "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+        },
+        "moment-timezone": {
+            "version": "0.5.27",
+            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.27.tgz",
+            "integrity": "sha512-EIKQs7h5sAsjhPCqN6ggx6cEbs94GK050254TIJySD1bzoM5JTYDwAU1IoVOeTOL6Gm27kYJ51/uuvq1kIlrbw==",
+            "requires": {
+                "moment": ">= 2.9.0"
+            }
+        },
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3131,7 +3182,6 @@
             "version": "6.5.3",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
             "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
-            "dev": true,
             "requires": {
                 "tslib": "^1.9.0"
             }
@@ -3171,6 +3221,15 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
             "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+        },
+        "sha.js": {
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+            "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
         },
         "shebang-command": {
             "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/selenehyun/contribe-api.git"
+        "url": "git+https://github.com/polym-team/contribe-api.git"
     },
     "keywords": [
         "contribe",
@@ -21,13 +21,14 @@
     "author": "selenehyun",
     "license": "ISC",
     "bugs": {
-        "url": "https://github.com/selenehyun/contribe-api/issues"
+        "url": "https://github.com/polym-team/contribe-api/issues"
     },
-    "homepage": "https://github.com/selenehyun/contribe-api#readme",
+    "homepage": "https://github.com/polym-team/contribe-api#readme",
     "dependencies": {
         "@hapi/boom": "^7.4.2",
         "@hapi/joi": "^15.1.0",
         "@koa/cors": "^2.2.3",
+        "class-transformer": "^0.2.3",
         "class-validator": "^0.9.1",
         "confidence": "^4.0.2",
         "http-graceful-shutdown": "^2.3.2",
@@ -39,8 +40,13 @@
         "koa-joi-router": "^6.0.0",
         "koa-joi-router-docs": "^0.1.9",
         "koa-jwt": "^3.6.0",
+        "lodash": "^4.17.15",
+        "moment": "^2.24.0",
+        "moment-timezone": "^0.5.27",
         "mysql": "^2.17.1",
         "reflect-metadata": "^0.1.13",
+        "rxjs": "^6.5.3",
+        "sha.js": "^2.4.11",
         "typedi": "^0.8.0",
         "typeorm": "^0.2.18",
         "uuid": "^3.3.3"
@@ -54,7 +60,11 @@
         "@types/koa": "^2.0.49",
         "@types/koa-joi-router": "^5.2.2",
         "@types/koa__cors": "^2.2.3",
+        "@types/lodash": "^4.14.149",
+        "@types/moment": "^2.13.0",
+        "@types/moment-timezone": "^0.5.12",
         "@types/node": "^12.6.1",
+        "@types/sha.js": "^2.4.0",
         "@types/uuid": "^3.4.6",
         "@typescript-eslint/parser": "^2.7.0",
         "eslint": "^6.5.1",

--- a/src/config/ormconfig.ts
+++ b/src/config/ormconfig.ts
@@ -1,5 +1,3 @@
-const entities: Object[] = [];
-
 export default {
     $filter: { $env: 'NODE_ENV' },
     production: {
@@ -11,7 +9,6 @@ export default {
         database: 'core',
         synchronize: false,
         logging: true,
-        entities,
         // migrations: ['src/migration/**/*.ts'],
         supportBigNumbers: true,
         bigNumberStrings: false,
@@ -20,12 +17,11 @@ export default {
         type: 'mysql',
         host: 'localhost',
         port: 3306,
-        username: 'root',
+        username: 'root', // TODO: value by environment
         password: '1234',
         database: 'core',
         synchronize: true,
         logging: true,
-        entities,
         // migrations: ['src/migration/**/*.ts'],
         supportBigNumbers: true,
         bigNumberStrings: false,

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -1,0 +1,3 @@
+import { User } from './services/users/domain/model';
+
+export default [User];

--- a/src/libs/ddd/ddd-context.ts
+++ b/src/libs/ddd/ddd-context.ts
@@ -1,0 +1,62 @@
+import { EntityManager } from 'typeorm';
+import { Container } from 'typedi';
+import { DddEvent } from './ddd-event';
+import * as uuid from 'uuid/v4';
+
+export class DddContext {
+    static of(txId: string): DddContext {
+        return new DddContext(txId);
+    }
+
+    dispose: () => void;
+
+    get: <T>(clazz: new (...args: any[]) => T) => T;
+
+    private constructor(txId: string) {
+        this._txId = txId;
+
+        const containerId = uuid();
+        const container = Container.of(containerId);
+        container.set(DddContext, this);
+
+        this.dispose = () => {
+            Container.reset(containerId);
+        };
+
+        this.get = (clazz) => container.get(clazz);
+    }
+
+    // @Inject('txId')
+    private _txId!: string;
+
+    get txId(): string {
+        // console.log(this._txId);
+        return this._txId;
+    }
+
+    // #region EntityManager
+    // @Inject()
+    private _entityManager!: EntityManager;
+
+    get entityManager(): EntityManager {
+        // console.log(this._txId);
+        return this._entityManager;
+    }
+
+    set entityManager(entityManager: EntityManager) {
+        this._entityManager = entityManager;
+    }
+    // #endregion
+
+    // #region event
+    private events: DddEvent[] = [];
+
+    publishEvents(events: DddEvent[]) {
+        this.events.push(...events);
+    }
+
+    getPublishedEvents(): DddEvent[] {
+        return [...this.events];
+    }
+    // #endregion
+}

--- a/src/libs/ddd/ddd-event.ts
+++ b/src/libs/ddd/ddd-event.ts
@@ -1,0 +1,56 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    CreateDateColumn,
+    UpdateDateColumn,
+    BeforeInsert,
+    AfterLoad,
+} from 'typeorm';
+
+@Entity()
+export abstract class DddEvent {
+    @PrimaryGeneratedColumn({ unsigned: true })
+    private id!: number;
+
+    @Column()
+    type: string;
+
+    @Column()
+    private occurredAt: Date;
+
+    @Column()
+    txId!: string;
+
+    @CreateDateColumn()
+    private createdAt!: Date;
+
+    @UpdateDateColumn()
+    private updatedAt!: Date;
+
+    // All stringified properties of the event except the properties which occupy columns.
+    @Column()
+    private data!: string;
+
+    @BeforeInsert()
+    private serialize() {
+        const { id, type, occurredAt, txId, createdAt, updatedAt, data, ...props } = this;
+        this.data = JSON.stringify(props);
+    }
+
+    @AfterLoad()
+    private deserialize() {
+        const props = JSON.parse(this.data);
+        Object.assign(this, props);
+    }
+
+    constructor() {
+        this.type = this.constructor.name;
+        this.occurredAt = new Date();
+    }
+
+    withTxId(txId: string) {
+        this.txId = txId;
+        return this;
+    }
+}

--- a/src/libs/ddd/ddd-model.ts
+++ b/src/libs/ddd/ddd-model.ts
@@ -1,0 +1,127 @@
+import { validate } from 'class-validator';
+import { flatMap } from 'lodash';
+import { CreateDateColumn, UpdateDateColumn, Column } from 'typeorm';
+import { Exclude } from 'class-transformer';
+import { Nullable } from '../types';
+import { DddEvent } from './ddd-event';
+
+export abstract class DddModel<T> {
+    /**
+     * Primary key를 제공하는 메서드 구현.
+     */
+    public getId(): number | string {
+        const identifierKey: string = Reflect.getMetadata(
+            `model:${this.constructor.name}:id`,
+            this.constructor.prototype,
+        );
+        // TODO: ts-ignore 없이는 못하나?
+        // @ts-ignore
+        return this[identifierKey];
+    }
+
+    /**
+     *
+     */
+    protected getClasses(): Function[] {
+        return [this.constructor];
+    }
+
+    /**
+     * FIXME: this 의 date type property 가 toNullable() 하면 string 으로 바뀌는것 같다
+     */
+    public toNullable(): Nullable<T> {
+        const nullable = {};
+        // TODO: MP-573
+        const propertyKeys = new Set(
+            flatMap(
+                this.getClasses(), //
+                (clazz) => Reflect.getMetadata(`model:${clazz.name}`, clazz.prototype),
+            ).filter((key) => !!key),
+        );
+        propertyKeys.forEach((propertyKey) => {
+            // FIXME: ts-ignore 없앨 수 있나?
+            // @ts-ignore
+            nullable[propertyKey] = typeof this[propertyKey] !== 'undefined' ? this[propertyKey] : null;
+        });
+        // FIXME: 더 좋은 방법이 있다면 수정해주면 좋겠다. https://github.com/Ecube-Labs/haulla-api/pull/86#issuecomment-517926696
+        return nullable as Nullable<T>;
+    }
+
+    // #region Audit columns
+    // 로직이나 쿼리로 인해 나중에 값이 채워지는 컬럼들이므로 validator로 검증하지 않는다.
+    // Response로 사용하지 않는다.
+    @Exclude()
+    @CreateDateColumn()
+    private createdAt!: Date;
+
+    @Exclude()
+    @Column()
+    private createdBy!: string;
+
+    @Exclude()
+    @UpdateDateColumn()
+    private updatedAt!: Date;
+
+    @Exclude()
+    @Column()
+    private updatedBy!: string;
+    // #endregion
+
+    protected async validate() {
+        const errors = await validate(this);
+        if (errors.length) {
+            throw errors;
+        }
+    }
+
+    setTxId(txId: string) {
+        if (!this.getId()) {
+            this.createdBy = txId;
+        }
+        this.updatedBy = txId;
+    }
+
+    // #region event
+    private events: DddEvent[] = [];
+
+    protected publishEvent(event: DddEvent) {
+        this.events.push(event);
+    }
+
+    public getPublishedEvents(): DddEvent[] {
+        return [...this.events];
+    }
+    // #endregion
+}
+
+/**
+ *
+ */
+export function Identifier(): Function {
+    return (target: Object, propertyKey: string) => {
+        // TODO: MP-573
+        const metadataKey = `model:${target.constructor.name}:id`;
+        const identifierKey = Reflect.getMetadata(metadataKey, target);
+        if (identifierKey) {
+            throw new Error('Only one identifier is allowed.');
+        }
+        Reflect.defineMetadata(metadataKey, propertyKey, target);
+    };
+}
+
+/**
+ *
+ */
+export function Property(): Function {
+    // @ts-ignore
+    return (target: Object, propertyKey: string) => {
+        // TODO: MP-573
+        const metadataKey = `model:${target.constructor.name}`;
+        const propertyKeys = Reflect.getMetadata(metadataKey, target);
+        if (propertyKeys) {
+            Reflect.defineMetadata(metadataKey, [...propertyKeys, propertyKey], target);
+        } else {
+            Reflect.defineMetadata(metadataKey, [propertyKey], target);
+        }
+    };
+}

--- a/src/libs/ddd/ddd-model.ts
+++ b/src/libs/ddd/ddd-model.ts
@@ -31,7 +31,6 @@ export abstract class DddModel<T> {
      */
     public toNullable(): Nullable<T> {
         const nullable = {};
-        // TODO: MP-573
         const propertyKeys = new Set(
             flatMap(
                 this.getClasses(), //
@@ -99,7 +98,6 @@ export abstract class DddModel<T> {
  */
 export function Identifier(): Function {
     return (target: Object, propertyKey: string) => {
-        // TODO: MP-573
         const metadataKey = `model:${target.constructor.name}:id`;
         const identifierKey = Reflect.getMetadata(metadataKey, target);
         if (identifierKey) {
@@ -115,7 +113,6 @@ export function Identifier(): Function {
 export function Property(): Function {
     // @ts-ignore
     return (target: Object, propertyKey: string) => {
-        // TODO: MP-573
         const metadataKey = `model:${target.constructor.name}`;
         const propertyKeys = Reflect.getMetadata(metadataKey, target);
         if (propertyKeys) {

--- a/src/libs/ddd/ddd-repository.ts
+++ b/src/libs/ddd/ddd-repository.ts
@@ -2,7 +2,6 @@ import { flatMap } from 'lodash';
 import { Inject } from 'typedi';
 import { badImplementation } from '@hapi/boom';
 import {
-    EntityManager,
     throwBy,
     DuplicateEntryError,
     Specification,

--- a/src/libs/ddd/ddd-repository.ts
+++ b/src/libs/ddd/ddd-repository.ts
@@ -1,0 +1,101 @@
+import { flatMap } from 'lodash';
+import { Inject } from 'typedi';
+import { badImplementation } from '@hapi/boom';
+import {
+    EntityManager,
+    throwBy,
+    DuplicateEntryError,
+    Specification,
+    ObjectType,
+    FindAllManyOptions,
+    FindOrder,
+    FindManyOptions,
+    convertOptions,
+} from '../orm';
+import { ResponseError } from '../response/error';
+import { DddModel } from './ddd-model';
+import { DddEvent } from './ddd-event';
+import { DddContext } from './ddd-context';
+
+export abstract class DddRepository<T extends DddModel<T>> {
+    @Inject()
+    private context!: DddContext;
+
+    protected entityClass?: ObjectType<T>; // ex) User
+
+    /**
+     * @param entities
+     */
+    public async save(entities: T[]) {
+        entities.forEach((entity) => entity.setTxId(this.context.txId));
+        // NOTE:
+        //   You can't call saveEntities() and saveEvents() parallel using Promise.all() since you have to wait until auto increment key's been generated.
+        //   See https://stackoverflow.com/questions/11277945/new-entity-id-in-domain-event
+        await this.saveEntities(entities);
+        await this.saveEvents(flatMap(entities, (entity) => entity.getPublishedEvents()));
+    }
+
+    /**
+     * @param entities
+     */
+    private async saveEntities(entities: T[]) {
+        return this.context.entityManager
+            .save(entities, { reload: true })
+            .catch(throwBy(this.context.entityManager))
+            .catch((err) => {
+                if (err instanceof DuplicateEntryError) {
+                    throw new DuplicateEntityError();
+                }
+                throw err;
+            });
+    }
+
+    /**
+     * @param events
+     */
+    private async saveEvents(events: DddEvent[]) {
+        const eventsWithTxId = events.map((event) => event.withTxId(this.context.txId));
+        this.context.publishEvents(eventsWithTxId);
+        return this.context.entityManager.save(DddEvent, eventsWithTxId);
+    }
+
+    /**
+     * @param spec
+     * @param options
+     * @param order
+     */
+    public async findAll(spec: Specification<T>, options?: FindManyOptions, order?: FindOrder): Promise<T[]> {
+        if (!this.entityClass) {
+            throw badImplementation<ResponseError>('findAll을 사용하려면 entityClass를 지정해야 합니다.', {
+                errorCode: 'UNEXPECTED',
+                errorMessage: 'bad implementation', // TODO: 에러 메세지
+            });
+        }
+        return this.context.entityManager.find<T>(this.entityClass, {
+            where: spec.where,
+            ...convertOptions(options),
+            ...order,
+        } as FindAllManyOptions<T>);
+    }
+
+    public async countAll(spec: Specification<T>): Promise<number> {
+        if (!this.entityClass) {
+            throw badImplementation<ResponseError>('countAll을 사용하려면 entityClass를 지정해야 합니다.', {
+                errorCode: 'UNEXPECTED',
+                errorMessage: 'bad implementation', // TODO: 에러 메세지
+            });
+        }
+        return this.context.entityManager.count<T>(this.entityClass, spec.where as FindAllManyOptions<T>);
+    }
+}
+
+/**
+ * 중복된 데이터를 추가하려는 경우 발생하는 에러.
+ */
+export class DuplicateEntityError extends Error {
+    constructor() {
+        super();
+        this.name = 'DuplicateEntityError';
+        Error.captureStackTrace(this, this.constructor);
+    }
+}

--- a/src/libs/ddd/ddd-service.ts
+++ b/src/libs/ddd/ddd-service.ts
@@ -1,0 +1,37 @@
+import { Inject } from 'typedi';
+import { getConnection } from 'typeorm';
+import { DddContext } from './ddd-context';
+import { DddEvent } from './ddd-event';
+import { registerEventHandler, handleEvents } from '../event-store';
+
+export class DddService {
+    @Inject()
+    context!: DddContext;
+}
+
+export function Transactional() {
+    return function(target: DddService, propertyKey: string, descriptor: PropertyDescriptor) {
+        const originalMethod = descriptor.value;
+        descriptor.value = async function(this: DddService) {
+            const thiz = this;
+            const args = arguments; // eslint-disable-line prefer-rest-params
+            let result: any;
+            await getConnection().manager.transaction(async (entityManager) => {
+                // Replace entityManager set in DddContext
+                // We should use entityManger. see https://github.com/typeorm/typeorm/issues/2927
+                thiz.context.entityManager = entityManager;
+                result = await originalMethod.apply(thiz, args);
+            });
+            handleEvents(thiz.context.getPublishedEvents());
+            return result;
+        };
+        return descriptor;
+    };
+}
+
+export function EventHandler<T extends DddEvent>(eventClass: new (...args: any[]) => T) {
+    return function(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+        // FIXME: target 이 DddService 를 상속하지 않으면 throw Error();
+        registerEventHandler(eventClass, target.constructor, propertyKey);
+    };
+}

--- a/src/libs/ddd/index.ts
+++ b/src/libs/ddd/index.ts
@@ -1,0 +1,6 @@
+export * from './ddd-context';
+export * from './ddd-model';
+export * from './ddd-repository';
+export * from './versioned-ddd-model';
+export * from './versioned-ddd-repository';
+export * from './ddd-service';

--- a/src/libs/ddd/versioned-ddd-model.ts
+++ b/src/libs/ddd/versioned-ddd-model.ts
@@ -1,0 +1,11 @@
+import { VersionColumn } from '../orm';
+import { DddModel } from './ddd-model';
+
+export abstract class VersionedDddModel<T extends VersionedDddModel<T>> extends DddModel<T> {
+    // NOTE:
+    // - version 은 not null 이어야 한다.
+    // - DddModel -> VersionedDddModel 로 변경할 경우 version 이 null 이 되는 것을 막기 위해 version = 1 을 기본값으로 설정한다.
+    // - version = 0 으로 하지 않은 이유는 !0 과 !undefined 모두 true 로 evaluate 하기 때문에 버그를 예방하기 위해서.
+    @VersionColumn({ default: 1 })
+    public version!: number;
+}

--- a/src/libs/ddd/versioned-ddd-repository.ts
+++ b/src/libs/ddd/versioned-ddd-repository.ts
@@ -1,0 +1,32 @@
+import { badRequest } from '@hapi/boom';
+import { ResponseError } from '../response/error';
+import { DddRepository } from './ddd-repository';
+import { VersionedDddModel } from './versioned-ddd-model';
+
+export abstract class VersionedDddRepository<T extends VersionedDddModel<T>> extends DddRepository<T> {
+    public async save(entities: T[]) {
+        const versionOf: { [key: string]: number } = entities.reduce((versionOf: { [key: string]: number }, entity) => {
+            if (entity.getId()) {
+                // id 가 없는 것은 새로 생성하는 entity. 새로 생성하는 entity 는 버젼 체크 대상이 아니다.
+                versionOf[entity.getId().toString()] = entity.version;
+            }
+            return versionOf;
+        }, {});
+
+        await super.save(entities);
+
+        entities
+            .filter((entity) => entity.version > 1) // version === 1 이면 새로 생성한 entity 이므로 버젼 체크 할 필요 없음
+            .forEach((entity, i) => {
+                if (entity.version !== versionOf[entity.getId().toString()] + 1) {
+                    throw badRequest<ResponseError>(
+                        `OptimisticLockVersionMismatchError(${entities[0].constructor.name}(${entity.getId()}))`,
+                        {
+                            errorCode: 'UNHANDLED',
+                            errorMessage: "Something went wrong and we couldn't complete your request.", // TODO: 메시지 정리
+                        },
+                    );
+                }
+            });
+    }
+}

--- a/src/libs/event-store/index.ts
+++ b/src/libs/event-store/index.ts
@@ -1,0 +1,44 @@
+import { Subject } from 'rxjs';
+import { DddContext } from '../ddd/ddd-context';
+import { DddEvent } from '../ddd/ddd-event';
+
+const handlers: [new (...args: any[]) => DddEvent, new (...args: any[]) => any, string][] = [];
+
+/**
+ * @param eventClass
+ * @param serviceClass
+ * @param serviceMethod
+ */
+export function registerEventHandler(
+    eventClass: new (...args: any[]) => DddEvent,
+    serviceClass: new (...args: any[]) => any, // TODO: any?
+    serviceMethod: string,
+) {
+    handlers.push([eventClass, serviceClass, serviceMethod]);
+}
+
+const subject = new Subject<DddEvent>();
+
+subject.subscribe((event) => {
+    handlers.forEach(([eventClass, serviceClass, serviceMethod]) => {
+        if (event.type === eventClass.name) {
+            const context = DddContext.of(event.txId);
+            const service = context.get(serviceClass);
+            // @ts-ignore
+            (service[serviceMethod].call(service, event) as Promise)
+                .catch((err: Error) => {
+                    console.error('TODO: error logging', err, event);
+                })
+                .finally(() => {
+                    context.dispose();
+                });
+        }
+    });
+});
+
+/**
+ * @param events
+ */
+export function handleEvents(events: DddEvent[]) {
+    events.forEach((event) => subject.next(event));
+}

--- a/src/libs/orm/index.ts
+++ b/src/libs/orm/index.ts
@@ -97,7 +97,7 @@ export const convertOptions = (options?: FindManyOptions) => {
     let skip;
     let take;
     if (options && options.page) {
-        skip = ((options.page || 1) - 1) * (options.limit || 1);
+        skip = (options.page - 1) * (options.limit || 1);
     }
     if (options && options.limit) {
         take = options.limit;

--- a/src/libs/orm/index.ts
+++ b/src/libs/orm/index.ts
@@ -1,0 +1,313 @@
+import * as _ from 'lodash';
+import {
+    PrimaryGeneratedColumn as TypeOrmPrimaryGeneratedColumn,
+    Column as TypeOrmColumn,
+    LessThan,
+    MoreThan,
+    FindOperator,
+    FindManyOptions as FindAllManyOptions,
+    EntityManager,
+} from 'typeorm';
+import * as moment from 'moment';
+
+export {
+    EntityManager,
+    getManager,
+    Entity,
+    ChildEntity,
+    TableInheritance,
+    CreateDateColumn,
+    UpdateDateColumn,
+    BeforeUpdate,
+    FindConditions,
+    Raw,
+    Not,
+    IsNull,
+    In,
+    Like,
+    Between,
+    ObjectType,
+    VersionColumn,
+    PrimaryColumn,
+    OneToMany,
+    ManyToOne,
+    PrimaryGeneratedColumn as PrimaryGeneratedColumn2,
+    Column as Column2,
+    AfterInsert,
+} from 'typeorm';
+
+export type FindAllManyOptions<T> = FindAllManyOptions<T>;
+
+/**
+ *
+ */
+export function PrimaryGeneratedColumn(...args: any[]): Function {
+    // @ts-ignore
+    const propertyDecorator = TypeOrmPrimaryGeneratedColumn(...args);
+    return (target: Object, propertyKey: string) => {
+        // TODO: MP-573
+        const metadataKey = `model:${target.constructor.name}`;
+        const propertyKeys = Reflect.getMetadata(metadataKey, target);
+        if (propertyKeys) {
+            Reflect.defineMetadata(metadataKey, [...propertyKeys, propertyKey], target);
+        } else {
+            Reflect.defineMetadata(metadataKey, [propertyKey], target);
+        }
+        propertyDecorator(target, propertyKey);
+    };
+}
+
+/**
+ *
+ */
+export function Column(...args: any[]): Function {
+    // @ts-ignore
+    const propertyDecorator = TypeOrmColumn(...args);
+    return (target: Object, propertyKey: string) => {
+        // TODO: MP-573
+        const metadataKey = `model:${target.constructor.name}`;
+        const propertyKeys = Reflect.getMetadata(metadataKey, target);
+        if (propertyKeys) {
+            Reflect.defineMetadata(metadataKey, [...propertyKeys, propertyKey], target);
+        } else {
+            Reflect.defineMetadata(metadataKey, [propertyKey], target);
+        }
+        propertyDecorator(target, propertyKey);
+    };
+}
+
+/**
+ * skip, take 외의 옵션은 허용하지 않는다
+ * @see https://ecubelabs.atlassian.net/wiki/spaces/WIKI/pages/186384414
+ */
+export interface FindManyOptions {
+    /**
+     * Page (paginated) where from entities should be taken.
+     * Starts from 1.
+     */
+    page?: number;
+    /**
+     * Limit (paginated) - max number of entities should be taken.
+     */
+    limit?: number;
+}
+
+/**
+ * @param options
+ */
+export const convertOptions = (options?: FindManyOptions) => {
+    let skip;
+    let take;
+    if (options && options.page) {
+        skip = ((options.page || 1) - 1) * (options.limit || 1);
+    }
+    if (options && options.limit) {
+        take = options.limit;
+    }
+    return {
+        skip,
+        take,
+    };
+};
+
+/**
+ *
+ */
+export interface FindOrder {
+    order: {
+        [prop: string]: 'DESC' | 'ASC';
+    };
+}
+
+/**
+ * @param prop
+ */
+export const desc = (prop: string): FindOrder => ({
+    order: {
+        [prop]: 'DESC',
+    },
+});
+
+/**
+ * @param prop
+ */
+export const asc = (prop: string): FindOrder => ({
+    order: {
+        [prop]: 'ASC',
+    },
+});
+
+/**
+ * LessThan is not working for date column
+ * @see https://github.com/typeorm/typeorm/issues/2286
+ * @param date
+ */
+export const LessThanDate = (date: Date) => LessThan(moment(date).format('YYYY-MM-DD HH:MM:SS'));
+
+/**
+ * MoreThan is not working for date column
+ * @see https://github.com/typeorm/typeorm/issues/2286
+ * @param date
+ */
+export const MoreThanDate = (date: Date) => MoreThan(moment(date).format('YYYY-MM-DD HH:MM:SS'));
+
+/**
+ * 중복된 데이터를 insert 하려는 경우 발생하는 에러.
+ */
+export class DuplicateEntryError extends Error {
+    constructor(public driver: string) {
+        super(driver);
+        this.name = 'DuplicateEntryError';
+        Error.captureStackTrace(this, this.constructor);
+    }
+}
+
+/**
+ * 각 드라이버마다 다른 에러 코드에 대한 에러 객체를 정의해둔다.
+ * OrmError에서 에러를 만들때 사용함.
+ */
+const ErrorMap: {
+    [key: string]: Record<number, any>; // TODO: any대신 ErrorConstructor 쓸 수 있게 바꿔야 함
+} = {
+    mysql: {
+        1062: DuplicateEntryError,
+    },
+    sqlite: {
+        19: DuplicateEntryError,
+    },
+};
+
+class OrmError extends Error {
+    /**
+     * DB driver 상관 없이 추상화 된 에러를 반환하기 위해 존재한다.
+     * @param err orm에서 반환한 에러를 입력받는다.
+     * @param driver 어떤 드라이버를 사용했는지 입력받는다.
+     */
+    static of(err: any, driver: string) {
+        const SelectedError = ErrorMap[driver][err.errno];
+        return SelectedError ? new SelectedError(driver) : err;
+    }
+}
+
+/**
+ * @param entityManager
+ */
+export const throwBy = (entityManager: EntityManager) => {
+    return (err: Error) => {
+        const driver = entityManager.connection.options.type;
+        throw OrmError.of(err, driver);
+    };
+};
+
+/**
+ * Array는 or 조건
+ * Object는 and 조건을 표현한것이다.
+ */
+type Condition<T> = {
+    [P in keyof T]?: Condition<T>[] | FindOperator<T | string | number> | string | number;
+};
+
+export const where = <T>(spec?: Specification<T> | Condition<T> | (Specification<T> | Condition<T>)[]) =>
+    new Specification<T>(spec);
+
+/**
+ * **!! 주의 !!** 동일한 프로퍼티를 필터링 하는 경우 아래의 사용 예를 따라야 합니다.
+ *
+ * 쿼리로 치면 아래같은 느낌이다.
+ * ```sql
+ * select ~~~ from ~~~ where id in (1, 2, 3) and id in (1)
+ * ```
+ * 객체 필터링의 책임을 전부 orm에 넘기지 마세요.
+ * ### 잘못된 예시
+ * ```ts
+ * const cond = where(isIdOfIn([1, 2, 3]))
+ *     .and(isIdOfIn([1])); // 1, 2, 3 집합 속에서 다시 1만 가져오고 싶다?
+ * repo.findAll(cond); // Error!
+ * ```
+ *
+ * 원하는 값을 계산해서 넘겨야 합니다.
+ * ### 올바른 예시
+ * ```ts
+ * const cond = where(isIdOfIn([1]));
+ * repo.findAll(cond);
+ * ```
+ */
+export class Specification<T> {
+    where: Condition<T> | Condition<T>[] = {};
+
+    get isEmpty(): boolean {
+        if (_.isArray(this.where)) {
+            return this.where.length === 0;
+        }
+        return Object.keys(this.where).length === 0;
+    }
+
+    // merge
+    constructor(spec?: Specification<T> | Condition<T> | (Specification<T> | Condition<T>)[]) {
+        if (spec) {
+            this.where = _.isArray(spec)
+                ? spec.map(Specification.specToCondition)
+                : Specification.specToCondition(spec);
+        }
+    }
+
+    static specToCondition<T>(spec: Specification<T> | Condition<T>) {
+        if (spec instanceof Specification) {
+            if (spec.isEmpty) {
+                return {};
+            }
+            return spec.where;
+        }
+        return spec;
+    }
+
+    and(spec: Specification<T>): Specification<T> {
+        if (spec.isEmpty) {
+            return this;
+        }
+        // TODO: 개 거지같은 병합. 여러 라이브러리들이 원하는 형태로 머지하지 않아서 일단 대충 조건 맞춰서 함
+        const src = { ...this.where };
+        Object.keys(spec.where).forEach((key) => {
+            if ((src as any)[key]) {
+                // src가 이미 여러 조건을 담았을때
+                if (_.isArray((src as any)[key])) {
+                    // dst도 여러 대상이면 그냥 합침
+                    if (_.isArray((spec.where as any)[key])) {
+                        (src as any)[key] = [...(src as any)[key], ...(spec.where as any)[key]];
+                    } else {
+                        (src as any)[key] = [...(src as any)[key], (spec.where as any)[key]];
+                    }
+                } else if (_.isArray((spec.where as any)[key])) {
+                    // dst가 여러 조건을 담았을때
+                    (src as any)[key] = [(src as any)[key], ...(spec.where as any)[key]];
+                } else {
+                    // 양쪽 다 배열이 아닌 경우
+                    (src as any)[key] = [(src as any)[key], (spec.where as any)[key]];
+                }
+            } else {
+                // 이미 존재하는게 없으니 그냥 그대로 넣어줌
+                (src as any)[key] = (spec.where as any)[key];
+            }
+        });
+        this.where = src;
+        return this;
+    }
+
+    or(spec: Specification<T>): Specification<T> {
+        if (spec.isEmpty) {
+            return this;
+        }
+        if (_.isArray(this.where)) {
+            this.where = [...this.where];
+        } else {
+            this.where = [this.where];
+        }
+
+        if (_.isArray(spec.where)) {
+            this.where.push(...spec.where);
+        } else {
+            this.where.push(spec.where);
+        }
+        return this;
+    }
+}

--- a/src/libs/orm/index.ts
+++ b/src/libs/orm/index.ts
@@ -45,7 +45,6 @@ export function PrimaryGeneratedColumn(...args: any[]): Function {
     // @ts-ignore
     const propertyDecorator = TypeOrmPrimaryGeneratedColumn(...args);
     return (target: Object, propertyKey: string) => {
-        // TODO: MP-573
         const metadataKey = `model:${target.constructor.name}`;
         const propertyKeys = Reflect.getMetadata(metadataKey, target);
         if (propertyKeys) {
@@ -64,7 +63,6 @@ export function Column(...args: any[]): Function {
     // @ts-ignore
     const propertyDecorator = TypeOrmColumn(...args);
     return (target: Object, propertyKey: string) => {
-        // TODO: MP-573
         const metadataKey = `model:${target.constructor.name}`;
         const propertyKeys = Reflect.getMetadata(metadataKey, target);
         if (propertyKeys) {

--- a/src/libs/password/hash.ts
+++ b/src/libs/password/hash.ts
@@ -1,0 +1,6 @@
+import * as ShaJs from 'sha.js';
+
+export const generateHash = (str: string) =>
+    ShaJs('sha512')
+        .update(str)
+        .digest('hex');

--- a/src/libs/password/index.ts
+++ b/src/libs/password/index.ts
@@ -1,0 +1,2 @@
+export * from './hash';
+export * from './salt';

--- a/src/libs/password/salt.ts
+++ b/src/libs/password/salt.ts
@@ -1,0 +1,9 @@
+import * as ShaJs from 'sha.js';
+
+/**
+ * 현재는 now.toISOString()을 SHA-256으로 사용
+ */
+export const generateSalt = () =>
+    ShaJs('sha256')
+        .update(new Date().toISOString())
+        .digest('hex');

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import {
 } from './middlewares';
 import { globalRouter } from './routes';
 import { getConfig } from './config';
+import entities from './entities';
 
 const isProd: boolean = getConfig('/isProduction');
 // NOTE: confidence로 가져오면 객체가 손상되기 때문에 여기서 분기 처리를 한다.
@@ -21,7 +22,7 @@ const corsWhitelist = isProd
 const ormconfig = getConfig('/ormconfig');
 
 (async () => {
-    const conn = await createConnection(ormconfig); // TODO: TEMP
+    const conn = await createConnection({ ...ormconfig, entities }); // TODO: TEMP
 
     const app = new Koa();
 

--- a/src/services/users/domain/model.ts
+++ b/src/services/users/domain/model.ts
@@ -1,0 +1,208 @@
+import { IsOptional, IsString, MaxLength, IsEmail, Length, IsDate } from 'class-validator';
+import { badRequest } from '@hapi/boom';
+import { PrimaryGeneratedColumn, Column, Entity } from '../../../libs/orm';
+import { ResponseError } from '../../../libs/response/error';
+import { generateSalt, generateHash } from '../../../libs/password';
+import { DddModel, Identifier } from '../../../libs/ddd';
+import { Nullable } from '../../../libs/types';
+
+type CtorType = {
+    email: string;
+    phoneNumber?: string;
+    password: string;
+    countryCode: string;
+    timezone: string;
+    language: string;
+};
+
+export type UserUpdateType = {
+    firstName?: string;
+    lastName?: string;
+    countryCode?: string;
+    timezone?: string;
+    language?: string;
+};
+
+@Entity()
+export class User extends DddModel<User> {
+    @PrimaryGeneratedColumn({ unsigned: true })
+    @Identifier()
+    userId!: number;
+
+    @Column()
+    @IsString()
+    @MaxLength(32)
+    @IsOptional()
+    firstName?: string;
+
+    @Column({ nullable: true })
+    @IsString()
+    @MaxLength(32)
+    @IsOptional()
+    lastName?: string;
+
+    @Column({ unique: true })
+    @IsEmail()
+    @Length(6, 64)
+    email!: string;
+
+    @Column({ nullable: true, unique: true })
+    @IsString()
+    @IsOptional()
+    phoneNumber?: string;
+
+    /**
+     * SHA-512
+     */
+    @Column({ length: 128 })
+    @IsString()
+    @Length(128)
+    password!: string;
+
+    /**
+     * generateSalt에 의해 들어간 값.
+     */
+    @Column({ length: 64 })
+    private passwordSalt!: string;
+
+    @Column()
+    @IsString()
+    @Length(2)
+    countryCode!: string;
+
+    @Column()
+    @IsString()
+    @MaxLength(32)
+    timezone!: string;
+
+    @Column()
+    @IsString()
+    @Length(2)
+    language!: string;
+
+    @Column({ nullable: true })
+    @IsDate()
+    @IsOptional()
+    registeredAt?: Date;
+
+    @Column({ nullable: true })
+    @IsDate()
+    @IsOptional()
+    unregisteredAt?: Date;
+
+    @Column({ nullable: true })
+    @IsDate()
+    @IsOptional()
+    termsAgreedAt?: Date;
+
+    @Column({ nullable: true })
+    @IsDate()
+    @IsOptional()
+    privacyAgreedAt?: Date;
+
+    /**
+     *
+     */
+    public toNullable(): Nullable<User> {
+        throw new Error(`NOT IMPLEMENTED ${this}`);
+    }
+
+    constructor(args?: CtorType) {
+        super();
+        if (args) {
+            this.email = args.email;
+            this.phoneNumber = args.phoneNumber;
+            this.countryCode = args.countryCode;
+            this.timezone = args.timezone;
+            this.language = args.language;
+
+            this.changePassword(args.password);
+
+            // NOTE: 아래 컬럼은 현재 기획상 별도로 관리되어야 하는 non-audit column
+            const now = new Date();
+            this.registeredAt = now;
+            this.termsAgreedAt = now;
+            this.privacyAgreedAt = now;
+        }
+    }
+
+    static async of(args: CtorType): Promise<User> {
+        const rs = new User(args);
+        await rs.validate();
+        return rs;
+    }
+
+    /**
+     * 기본적인 사용자 정보를 업데이트 할 수 있음
+     */
+    async update({ firstName, lastName, countryCode, timezone, language }: UserUpdateType): Promise<User> {
+        if (firstName !== undefined) {
+            this.firstName = firstName;
+        }
+        if (lastName !== undefined) {
+            this.lastName = lastName;
+        }
+        if (countryCode !== undefined) {
+            this.countryCode = countryCode;
+        }
+        if (timezone !== undefined) {
+            this.timezone = timezone;
+        }
+        if (language !== undefined) {
+            this.language = language;
+        }
+
+        try {
+            await this.validate();
+        } catch (err) {
+            throw badRequest<ResponseError>('사용자 모델 validate 실패', {
+                errorCode: 'UNHANDLED',
+                errorMessage: 'Unacceptable format.',
+            });
+        }
+        return this;
+    }
+
+    /**
+     * 패스워드 변경
+     */
+    changePassword(originPassword: string) {
+        this.passwordSalt = generateSalt();
+        this.password = generateHash(`${originPassword}${this.passwordSalt}`);
+    }
+
+    /**
+     * 모델이 갖고 있는 패스워드가 인자의 패스워드와 동일한지 검사함.
+     * throw하지 않으면 유효한것.
+     */
+    async validatePassword(password: string): Promise<User> {
+        const expectedPassword = generateHash(`${password}${this.passwordSalt}`);
+        if (this.password !== expectedPassword) {
+            throw badRequest<ResponseError>('패스워드 검증 실패', {
+                errorCode: 'UNAUTH',
+                errorMessage: 'Authentication failed', // TODO: 에러 메세지!!
+            });
+        }
+        return this;
+    }
+
+    /**
+     * 이메일 변경.
+     * TODO: 미래엔 복잡해질것
+     * TODO: 인증 관련 처리
+     * @param email
+     */
+    changeEmail(email: string) {
+        this.email = email;
+    }
+
+    /**
+     * 연락처 변경.
+     * TODO: 미래엔 복잡해질것
+     * TODO: 인증 관련 처리
+     * @param phoneNumber
+     */
+    changePhoneNumber(phoneNumber: string) {
+        this.phoneNumber = phoneNumber;
+    }
+}


### PR DESCRIPTION
- ddd 패턴을 위한 추상화 라이브러리 추가
- 사용자 모델 + 엔티티 작성

[User Model](https://github.com/polym-team/contribe-api/wiki/%5BDomain-Model%5D-User)
passwordSalt같이 개발적인 이슈로 인해 도메인 내부적으로 필요한 엔티티 컬럼은 도메인 모델 문서에 작성하지 않습니다.